### PR TITLE
Correct recommended render width

### DIFF
--- a/bin/driver-proxy/src/driver/hmd.rs
+++ b/bin/driver-proxy/src/driver/hmd.rs
@@ -63,7 +63,7 @@ impl IVRDisplayComponent for HmdDisplay {
 	fn GetRecommendedRenderTargetSize(&self, pnWidth: *mut u32, pnHeight: *mut u32) {
 		let Mode { width, height, .. } = self.mode;
 		unsafe {
-			*pnWidth = width;
+			*pnWidth = width / 2;
 			*pnHeight = height;
 		}
 	}


### PR DESCRIPTION
The recommended width shall be reported for per-eye resolution that is a half of display's mode width.