### PR TITLE
Fix 0002-drm-edid-parse-DRM-VESA-dsc-bpp-target.patch to work on kernel 6.10

### DIFF
--- a/kernel-patches/0002-drm-edid-parse-DRM-VESA-dsc-bpp-target.patch
+++ b/kernel-patches/0002-drm-edid-parse-DRM-VESA-dsc-bpp-target.patch
@@ -11,7 +11,7 @@ Signed-off-by: Yaroslav Bolyukin <iam@lach.pw>
 ---
  drivers/gpu/drm/drm_edid.c  | 42 ++++++++++++++++++++++++-------------
  include/drm/drm_connector.h |  5 +++++
- include/drm/drm_displayid.h |  4 ++++
+ drivers/gpu/drm/drm_displayid_internal.h |  4 ++++
  3 files changed, 37 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
@@ -102,10 +102,10 @@ index 9037f1317aee..c1ca26142975 100644
  };
  
  int drm_display_info_set_bus_formats(struct drm_display_info *info,
-diff --git a/include/drm/drm_displayid.h b/include/drm/drm_displayid.h
+diff --git a/drivers/gpu/drm/drm_displayid_internal.h b/drivers/gpu/drm/drm_displayid_internal.h
 index 49649eb8447e..ada2f8e7681c 100644
---- a/include/drm/drm_displayid.h
-+++ b/include/drm/drm_displayid.h
+--- a/drivers/gpu/drm/drm_displayid_internal.h
++++ b/drivers/gpu/drm/drm_displayid_internal.h
 @@ -131,12 +131,16 @@ struct displayid_detailed_timing_block {
  
  #define DISPLAYID_VESA_MSO_OVERLAP	GENMASK(3, 0)


### PR DESCRIPTION
On kernel 6.10 the location and name of `include/drm/drm_displayid.h` changed to `drivers/gpu/drm/drm_displayid_internal.h` as seen in this [kernel commit](https://github.com/torvalds/linux/commit/44e030d8a5a1be503301a0f095416c5ebb93c9e6). This change breaks the `0002-drm-edid-parse-DRM-VESA-dsc-bpp-target.patch` file and as such this pull request changes the location and name to fix the issue.