### PR TITLE
Now works with Fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /result
 /dist-proxy/lens-server/lens-server.exe
 /dist-proxy/driver_lighthouse.so
+/kernel-patches/kernel
+/kernel-patches/kernel-rpms

--- a/kernel-patches/0001-drm-edid-Add-Bigscreen-Beyond-to-non-desktop-l.patch
+++ b/kernel-patches/0001-drm-edid-Add-Bigscreen-Beyond-to-non-desktop-l.patch
@@ -1,0 +1,14 @@
+diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
+index 3b4065099..639699e3b 100644
+--- a/drivers/gpu/drm/drm_edid.c
++++ b/drivers/gpu/drm/drm_edid.c
+@@ -189,6 +189,9 @@ static const struct edid_quirk {
+ 	/* Rotel RSX-1058 forwards sink's EDID but only does HDMI 1.1*/
+ 	EDID_QUIRK('E', 'T', 'R', 13896, EDID_QUIRK_FORCE_8BPC),
+ 
++	/* Bigscreen Beyond Headset */
++	EDID_QUIRK('B', 'I', 'G', 0x1234, EDID_QUIRK_NON_DESKTOP),
++
+ 	/* Valve Index Headset */
+ 	EDID_QUIRK('V', 'L', 'V', 0x91a8, EDID_QUIRK_NON_DESKTOP),
+ 	EDID_QUIRK('V', 'L', 'V', 0x91b0, EDID_QUIRK_NON_DESKTOP),

--- a/kernel-patches/0002-drm-edid-parse-DRM-VESA-dsc-bpp-target.patch
+++ b/kernel-patches/0002-drm-edid-parse-DRM-VESA-dsc-bpp-target.patch
@@ -27,7 +27,7 @@ index 767a3e3fa6e1..db6953f0e33b 100644
  		drm_dbg_kms(connector->dev,
  			    "[CONNECTOR:%d:%s] Unexpected VESA vendor block size\n",
  			    connector->base.id, connector->name);
-@@ -6312,24 +6312,37 @@ static void drm_parse_vesa_mso_data(struct drm_connector *connector,
+@@ -6510,24 +6510,37 @@ static void drm_parse_vesa_mso_data(struct drm_connector *connector,
  		break;
  	}
  
@@ -78,35 +78,39 @@ index 767a3e3fa6e1..db6953f0e33b 100644
  }
  
  static void drm_update_mso(struct drm_connector *connector,
-@@ -6376,6 +6389,7 @@ static void drm_reset_display_info(struct drm_connector *connector)
+@@ -6612,4 +6625,5 @@ static void drm_reset_display_info(struct drm_connector *connector)
  	info->mso_stream_count = 0;
  	info->mso_pixel_overlap = 0;
  	info->max_dsc_bpp = 0;
 +	info->dp_dsc_bpp = 0;
- }
  
- static u32 update_display_info(struct drm_connector *connector,
+
 diff --git a/include/drm/drm_connector.h b/include/drm/drm_connector.h
 index 9037f1317aee..c1ca26142975 100644
 --- a/include/drm/drm_connector.h
 +++ b/include/drm/drm_connector.h
-@@ -721,6 +721,11 @@ struct drm_display_info {
+@@ -836,7 +836,13 @@
  	 * monitor's default value is used instead.
  	 */
  	u32 max_dsc_bpp;
+-
++	
 +	/**
 +	 * @dp_dsc_bpp: DP Display-Stream-Compression (DSC) timing's target
 +	 * DST bits per pixel in 6.4 fixed point format. 0 means undefined
 +	 */
 +	u16 dp_dsc_bpp;
- };
- 
- int drm_display_info_set_bus_formats(struct drm_display_info *info,
++	    
+ 	/**
+ 	 * @vics: Array of vics_len VICs. Internal to EDID parsing.
+ 	 */
+
+
 diff --git a/drivers/gpu/drm/drm_displayid_internal.h b/drivers/gpu/drm/drm_displayid_internal.h
 index 49649eb8447e..ada2f8e7681c 100644
 --- a/drivers/gpu/drm/drm_displayid_internal.h
 +++ b/drivers/gpu/drm/drm_displayid_internal.h
-@@ -131,12 +131,16 @@ struct displayid_detailed_timing_block {
+@@ -131,13 +131,17 @@ struct displayid_detailed_timing_block {
  
  #define DISPLAYID_VESA_MSO_OVERLAP	GENMASK(3, 0)
  #define DISPLAYID_VESA_MSO_MODE		GENMASK(6, 5)
@@ -122,7 +126,8 @@ index 49649eb8447e..ada2f8e7681c 100644
 +	u8 dsc_bpp_fract;
  } __packed;
  
- /* DisplayID iteration */
+ /*
+  * DisplayID iteration.
 -- 
 2.38.1
 

--- a/kernel-patches/0003-drm-amd-use-fixed-dsc-bits-per-pixel-from-edid.patch
+++ b/kernel-patches/0003-drm-amd-use-fixed-dsc-bits-per-pixel-from-edid.patch
@@ -18,9 +18,9 @@ diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c b/drivers
 index e47098fa5aac..1c9c4925ed2f 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c
-@@ -87,6 +87,8 @@ enum dc_edid_status dm_helpers_parse_edid_caps(
+@@ -129,6 +129,8 @@ enum dc_edid_status dm_helpers_parse_edid_caps(
  
- 	edid_caps->edid_hdmi = connector->display_info.is_hdmi;
+ 	apply_edid_quirks(edid_buf, edid_caps);
  
 +	edid_caps->dsc_fixed_bits_per_pixel_x16 = connector->display_info.dp_dsc_bpp;
 +
@@ -31,7 +31,7 @@ diff --git a/drivers/gpu/drm/amd/display/dc/core/dc_stream.c b/drivers/gpu/drm/a
 index 38d71b5c1f2d..f2467b64268b 100644
 --- a/drivers/gpu/drm/amd/display/dc/core/dc_stream.c
 +++ b/drivers/gpu/drm/amd/display/dc/core/dc_stream.c
-@@ -103,6 +103,8 @@ static bool dc_stream_construct(struct dc_stream_state *stream,
+@@ -108,6 +108,8 @@ static bool dc_stream_construct(struct dc_stream_state *stream,
  
  	/* EDID CAP translation for HDMI 2.0 */
  	stream->timing.flags.LTE_340MCSC_SCRAMBLE = dc_sink_data->edid_caps.lte_340mcsc_scramble;
@@ -44,7 +44,7 @@ diff --git a/drivers/gpu/drm/amd/display/dc/dc_types.h b/drivers/gpu/drm/amd/dis
 index dc78e2404b48..65915a10ab48 100644
 --- a/drivers/gpu/drm/amd/display/dc/dc_types.h
 +++ b/drivers/gpu/drm/amd/display/dc/dc_types.h
-@@ -231,6 +231,9 @@ struct dc_edid_caps {
+@@ -208,6 +208,9 @@ struct dc_edid_caps {
  	bool edid_hdmi;
  	bool hdr_supported;
  

--- a/kernel-patches/build-fedora.sh
+++ b/kernel-patches/build-fedora.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+KERNEL_BRANCH=$(uname -r | awk -F. '{print $(NF-1)}' | sed -e 's/fc/f/')
+
+clear
+
+# Change working directory to script's directory
+cd $(dirname "$0")
+
+# Change to the kernel source directory and update
+cd kernel || { echo "Cannot change directory to kernel"; exit 1; }
+
+echo "Updating repo to latest kernel release version..."
+git pull origin $KERNEL_BRANCH --rebase
+echo "Updated repo to latest kernel release version"
+echo
+
+# Build the local kernel packages for release “f41”
+echo "Compiling kernel..."
+fedpkg --release $KERNEL_BRANCH local
+echo
+echo "Kernel compiled"
+echo
+
+# Extract the kernel version from one of the RPM filenames
+KERNEL_RPM=$(ls x86_64/kernel-*.rpm 2>/dev/null | head -n 1)
+if [[ -z "$KERNEL_RPM" ]]; then
+  echo "No kernel RPM files were found in x86_64. Exiting."
+  exit 1
+fi
+
+# The regex below looks for a pattern like: kernel-<major>.<minor>.<patch>e.g. kernel-5.15.12...rpm
+KERNEL_VER=$(echo "$KERNEL_RPM" | sed -E 's/.*kernel-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+).*\.rpm/\1/')
+if [[ -z "$KERNEL_VER" ]]; then
+  echo "Could not determine kernel version from RPM name: $KERNEL_RPM"
+  exit 1
+fi
+
+echo "Kernel version identified as $KERNEL_VER"
+
+echo "Installing new kernel packages..."
+echo "If sudo times out, run ./update-fedora.sh"
+../update-fedora.sh

--- a/kernel-patches/install-fedora.sh
+++ b/kernel-patches/install-fedora.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+FedoraVersion=$(uname -r | awk -F. '{print $(NF-1)}' | sed -e 's/fc/f/')
+BranchName=$(echo DSC-Patch-$(uname -r | awk -F. '{print $(NF-1)}' | sed -e 's/fc/f/'))
+
+#Sometimes git cloning fails. This ensures it sucessfully clones the repo.
+while true; do
+  if git clone https://src.fedoraproject.org/rpms/kernel.git; then
+    echo "Clone successful!"
+    break
+  else
+    echo "Clone failed, retrying..."
+  fi
+done
+
+#Make archive for the most recent 3 installed kernels
+mkdir kernel-rpms
+cd kernel
+
+git switch $FedoraVersion
+
+git checkout -b $BranchName
+
+patch kernel.spec ../kernel.spec.patch
+cp ../000* ./
+
+git add 000*
+git stage kernel.spec
+git commit -m "Added & applied kernel patches"

--- a/kernel-patches/kernel.spec.patch
+++ b/kernel-patches/kernel.spec.patch
@@ -1,0 +1,26 @@
+--- kernel.spec.old	2024-11-10 16:41:26.110148883 +0000
++++ kernel.spec	2024-11-09 01:28:19.723086738 +0000
+@@ -1018,6 +1018,11 @@
+ Patch1: patch-%{patchversion}-redhat.patch
+ %endif
+ 
++Patch10000: 0001-drm-edid-Add-Bigscreen-Beyond-to-non-desktop-l.patch
++Patch10001: 0001-drm-edid-Add-Vive-Cosmos-Vive-Pro-2-to-non-desktop-l.patch
++Patch10002: 0002-drm-edid-parse-DRM-VESA-dsc-bpp-target.patch
++Patch10003: 0003-drm-amd-use-fixed-dsc-bits-per-pixel-from-edid.patch
++
+ # empty final patch to facilitate testing of kernel patches
+ Patch999999: linux-kernel-test.patch
+ 
+@@ -1862,6 +1866,11 @@
+ 
+ ApplyOptionalPatch linux-kernel-test.patch
+ 
++ApplyOptionalPatch 0001-drm-edid-Add-Bigscreen-Beyond-to-non-desktop-l.patch
++ApplyOptionalPatch 0001-drm-edid-Add-Vive-Cosmos-Vive-Pro-2-to-non-desktop-l.patch
++ApplyOptionalPatch 0002-drm-edid-parse-DRM-VESA-dsc-bpp-target.patch
++ApplyOptionalPatch 0003-drm-amd-use-fixed-dsc-bits-per-pixel-from-edid.patch
++
+ %{log_msg "End of patch applications"}
+ # END OF PATCH APPLICATIONS
+ 

--- a/kernel-patches/update-fedora.sh
+++ b/kernel-patches/update-fedora.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Kernel branch; e.g.: f41 / rawhide
+KERNEL_BRANCH=$(uname -r | awk -F. '{print $(NF-1)}' | sed -e 's/fc/f/')
+# Kernel version installed
+KERNEL_INSTALLED=$(uname -r | sed -e "s/\.$(uname -r | awk -F. '{print $(NF-1)}').*//")
+# Directory to check for compiled kernels
+KERNEL_RPM_DIR="./kernel-rpms"
+# Number of previous compiled kernels to keep
+NUM_VERSIONS_TO_KEEP=4
+# Kernel Version format (e.g., 5.15.10-200)
+VERSION_REGEX="^.*[0-9]+\.[0-9]+\.[0-9]+-[0-9]+.*$"
+
+# Change working directory to script's directory
+cd $(dirname "$0")
+
+# Change to the kernel source directory and update
+cd kernel || { echo "Cannot change directory to kernel"; exit 1; }
+
+# Extract the kernel version from one of the RPM filenames
+KERNEL_RPM=$(ls x86_64/kernel-*.rpm 2>/dev/null | head -n 1)
+if [[ -z "$KERNEL_RPM" ]]; then
+  KERNEL_RPM=$(ls ../kernel-rpms/$KERNEL_INSTALLED/kernel-*.rpm 2>/dev/null | head -n 1)
+  if [[ -z "$KERNEL_RPM" ]]; then
+    echo "No kernel RPM files were found in x86_64. Exiting."
+    exit 1
+  fi
+  REINSTALL=true
+  read -p "Do you want to reinstall the most recent compiled kernel ($KERNEL_INSTALLED)? (y/n) " answer
+  if [[ $answer != y ]] || [[ $answer != yes ]] || [[ $answer != Y ]] || [[ $answer != YES ]] || [[ $answer != Yes ]]; then
+    echo "Exiting..."
+    #exit 1
+  fi
+fi
+
+# The regex below looks for a pattern like: kernel-<major>.<minor>.<patch>-<???>e.g. kernel-5.15.12-200...rpm
+KERNEL_VER=$(echo "$KERNEL_RPM" | sed -E 's/.*kernel-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+).*\.rpm/\1/')
+if [[ -z "$KERNEL_VER" ]]; then
+  echo "Could not determine kernel version from RPM name: $KERNEL_RPM"
+  exit 1
+fi
+
+echo "Kernel version compiled: $KERNEL_VER"
+echo "Kernel version installed: $KERNEL_INSTALLED"
+
+if [[ $KERNEL_VER == $KERNEL_INSTALLED ]]; then
+    echo "Reinstalling new kernel packages..."
+    echo "If sudo times out, run ./update-fedora.sh"
+    # Install the generated RPM packages
+    sudo dnf reinstall --nogpgcheck \
+        ./x86_64/kernel-[0-9]*.rpm \
+        ./x86_64/kernel-{core*.rpm,modules-[0-9]*.rpm,modules-core*.rpm,modules-extra*.rpm,devel-[0-9]*.rpm,devel-matched-[0-9]*.rpm}
+else
+    echo "Installing new kernel packages..."
+    echo "If sudo times out, run ./update-fedora.sh"
+    # Install the generated RPM packages
+    sudo dnf install --nogpgcheck \
+        ./x86_64/kernel-[0-9]*.rpm \
+        ./x86_64/kernel-{core*.rpm,modules-[0-9]*.rpm,modules-core*.rpm,modules-extra*.rpm,devel-[0-9]*.rpm,devel-matched-[0-9]*.rpm}
+fi
+echo "Kernel updated"
+echo
+
+# Create the destination directory named for the kernel version
+DEST_DIR="../kernel-rpms/$KERNEL_VER"
+ARCHIVE_DIR="../kernel-rpms"
+mkdir -p "$DEST_DIR"
+
+# Move all RPMs containing the version into the dedicated directory
+if [[ $REINSTALL != true ]]; then
+  mv x86_64/*"${KERNEL_VER}"*.rpm "$DEST_DIR"/
+fi
+
+# Now, delete directories in ../kernel-rpms that are older than the current plus 3 previous versions.
+cd "$ARCHIVE_DIR" || { echo "Cannot change to ../kernel-rpms"; exit 1; }
+
+    # Initialize the directories array
+    declare -a directories
+
+    # Find directories matching the regex and extract the version string
+    #directories=$(
+    directories=($(find ".$KERNEL_RPM_DIR" -maxdepth 1 -type d -regex "$VERSION_REGEX" |
+      sed -E 's/^\./\0/' |  # Add leading dot for sort -V
+      sort -V))
+
+    # Calculate the number of directories to delete
+    num_to_delete=$(( ${#directories[@]} - $NUM_VERSIONS_TO_KEEP ))
+    echo "To delete: $num_to_delete old versions"
+
+    # Delete the oldest directories
+    for ((i=0; i<$num_to_delete; i++)); do
+      dir_to_delete="${directories[$i]}"
+      echo "Deleting directory: $dir_to_delete"
+      rm -rf "$dir_to_delete"
+    done
+
+echo "Kernel updated, RPMs backed up, and old RPMs removed."
+echo
+read -p "Do you want to update all other packages and flatpaks on this system? (y/n) " answer
+if [[ $answer == y ]] || [[ $answer == yes ]] || [[ $answer == Y ]] || [[ $answer == YES ]] || [[ $answer == Yes ]]; then
+    echo "Updating remaining packages and flatpaks..."
+    sudo dnf update --refresh -y --exclude=kernel,kernel-core,kernel-modules,kernel-modules-core,kernel-modules-extra,kernel-devel,kernel-devel-matched
+    flatpak update -y
+    echo "Updated remaining packages and flatpaks"
+fi


### PR DESCRIPTION
Modified kernel patches 0002 and 0003 to work with the Fedora kernel
Added Bigscreen Beyond to non-desktop monitors
Added an install script for fetching and preparing for compiling the Fedora kernel Added a build scsript for compiling the Fedora kernel, with an additional
  update script that (re)installs the kernel, the latter of which can be called should the auto-install from the build script timeout waiting for a sudo password