### PR TITLE
Update kernel patch for kernel version 6.16.8

### DIFF
--- a/kernel-patches/0001-drm-edid-Add-Vive-Cosmos-Vive-Pro-2-to-non-desktop-l.patch
+++ b/kernel-patches/0001-drm-edid-Add-Vive-Cosmos-Vive-Pro-2-to-non-desktop-l.patch
@@ -17,7 +17,7 @@ index 3841aba17abd..767a3e3fa6e1 100644
  	EDID_QUIRK('V', 'L', 'V', 0x91bf, BIT(EDID_QUIRK_NON_DESKTOP)),
  
 -	/* HTC Vive and Vive Pro VR Headsets */
-+	/* HTC Vive, Vive Cosmos, Vive Pro and Vive Pro 2 VR Headsets */
++	/* HTC Vive, Vive Pro, Vive Cosmos and Vive Pro 2 VR Headsets */
  	EDID_QUIRK('H', 'V', 'R', 0xaa01, BIT(EDID_QUIRK_NON_DESKTOP)),
  	EDID_QUIRK('H', 'V', 'R', 0xaa02, BIT(EDID_QUIRK_NON_DESKTOP)),
 +	EDID_QUIRK('H', 'V', 'R', 0xaa03, BIT(EDID_QUIRK_NON_DESKTOP)),

--- a/kernel-patches/0001-drm-edid-Add-Vive-Cosmos-Vive-Pro-2-to-non-desktop-l.patch
+++ b/kernel-patches/0001-drm-edid-Add-Vive-Cosmos-Vive-Pro-2-to-non-desktop-l.patch
@@ -13,18 +13,18 @@ index 3841aba17abd..767a3e3fa6e1 100644
 --- a/drivers/gpu/drm/drm_edid.c
 +++ b/drivers/gpu/drm/drm_edid.c
 @@ -205,9 +205,11 @@ static const struct edid_quirk {
- 	EDID_QUIRK('V', 'L', 'V', 0x91be, EDID_QUIRK_NON_DESKTOP),
- 	EDID_QUIRK('V', 'L', 'V', 0x91bf, EDID_QUIRK_NON_DESKTOP),
+ 	EDID_QUIRK('V', 'L', 'V', 0x91be, BIT(EDID_QUIRK_NON_DESKTOP)),
+ 	EDID_QUIRK('V', 'L', 'V', 0x91bf, BIT(EDID_QUIRK_NON_DESKTOP)),
  
 -	/* HTC Vive and Vive Pro VR Headsets */
 +	/* HTC Vive, Vive Cosmos, Vive Pro and Vive Pro 2 VR Headsets */
- 	EDID_QUIRK('H', 'V', 'R', 0xaa01, EDID_QUIRK_NON_DESKTOP),
- 	EDID_QUIRK('H', 'V', 'R', 0xaa02, EDID_QUIRK_NON_DESKTOP),
-+	EDID_QUIRK('H', 'V', 'R', 0xaa03, EDID_QUIRK_NON_DESKTOP),
-+	EDID_QUIRK('H', 'V', 'R', 0xaa04, EDID_QUIRK_NON_DESKTOP),
+ 	EDID_QUIRK('H', 'V', 'R', 0xaa01, BIT(EDID_QUIRK_NON_DESKTOP)),
+ 	EDID_QUIRK('H', 'V', 'R', 0xaa02, BIT(EDID_QUIRK_NON_DESKTOP)),
++	EDID_QUIRK('H', 'V', 'R', 0xaa03, BIT(EDID_QUIRK_NON_DESKTOP)),
++	EDID_QUIRK('H', 'V', 'R', 0xaa04, BIT(EDID_QUIRK_NON_DESKTOP)),
  
  	/* Oculus Rift DK1, DK2, CV1 and Rift S VR Headsets */
- 	EDID_QUIRK('O', 'V', 'R', 0x0001, EDID_QUIRK_NON_DESKTOP),
+ 	EDID_QUIRK('O', 'V', 'R', 0x0001, BIT(EDID_QUIRK_NON_DESKTOP)),
 -- 
 2.38.1
 


### PR DESCRIPTION
Starting with kernel version `6.16.8`, the first kernel patch could no longer be applied because all `EDID_QUIRK_NON_DESKTOP` were wrapped in `BIT(` `)`  in [this commit](https://github.com/torvalds/linux/commit/5281cbe0b55a1ff9c6c29361540016873bdc506e).